### PR TITLE
add planner to compose

### DIFF
--- a/docker-compose.auv8.yml
+++ b/docker-compose.auv8.yml
@@ -270,6 +270,19 @@ services:
     environment:
       - ROS_IP=${ADRESS_IP}
       - ROS_MASTER_URI=http://${ADRESS_IP}:11311
+      - AUV=${AUV}
     network_mode: host
+    depends_on:
+      - ros-master
+
+  proc_planner:
+    image: ghcr.io/sonia-auv/proc_planner/proc_planner:arm64-perception-fix-basic-repo
+    container_name: proc_planner
+    environment:
+      - ROS_IP=${ADRESS_IP}
+      - ROS_MASTER_URI=http://${ADRESS_IP}:11311
+      - AUV=${AUV}
+    network_mode: host
+    privileged: true
     depends_on:
       - ros-master

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -263,3 +263,15 @@ services:
   #     depends_on:
   #       - ros-master
   #     command: stdbuf -o L roslaunch --wait proc_underwater_com proc_underwater_com.launch
+
+  proc_planner:
+    image: ghcr.io/sonia-auv/proc_planner/proc_planner:x86-perception-fix-basic-repo
+    container_name: proc_planner
+    environment:
+      - ROS_IP=${ADRESS_IP}
+      - ROS_MASTER_URI=http://${ADRESS_IP}:11311
+      - AUV=${AUV}
+    network_mode: host
+    privileged: true
+    depends_on:
+      - ros-master


### PR DESCRIPTION
Add the proc planner to both AUV8 and local docker compose.

AUV7 hasn't been change since I think we could get rid of it