### PR TITLE
add components to debug rs485 in local

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -205,21 +205,35 @@ services:
   #     - ros-master
 
   interface_rs485:
-    image: ghcr.io/sonia-auv/interface_rs485/interface_rs485:x86-perception-fix-simulation
+    image: ghcr.io/sonia-auv/interface_rs485/interface_rs485:x86-perception-develop
     container_name: interface_rs485
     environment:
       - ROS_IP=${ADRESS_IP}
       - ROS_MASTER_URI=http://${ADRESS_IP}:11311
-      - AUV=${LOCAL_AUV}
+      - AUV=${AUV}
     network_mode: host
     privileged: true
+    volumes:
+      - /dev/ttyUSB0:/dev/ttyUSB0
     depends_on:
      - ros-master
-    command:
-     - roslaunch
-     - --wait
-     - interface_rs485
-     - interface_rs485_sim.launch
+
+  # interface_rs485:
+  #   image: ghcr.io/sonia-auv/interface_rs485/interface_rs485:x86-perception-develop
+  #   container_name: interface_rs485
+  #   environment:
+  #     - ROS_IP=${ADRESS_IP}
+  #     - ROS_MASTER_URI=http://${ADRESS_IP}:11311
+  #     - AUV=${LOCAL_AUV}
+  #   network_mode: host
+  #   privileged: true
+  #   depends_on:
+  #    - ros-master
+  #   command:
+  #    - roslaunch
+  #    - --wait
+  #    - interface_rs485
+  #    - interface_rs485_sim.launch
 
   # provider_vision:
   #   image: ghcr.io/sonia-auv/provider_vision/provider_vision:x86-perception-feature-testing-modif


### PR DESCRIPTION
**Warning :** Before creating a pull request, make sure that it does not already exists in the [pull requests](../). Thank you.

## Description
Add the possibility to debug the rs485 for the hardware team

## How has this been tested ?
Tested with the rs485 and killswitch

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings